### PR TITLE
fix: handle situation where mapbox doesn't include context in response

### DIFF
--- a/Mapbox.php
+++ b/Mapbox.php
@@ -280,10 +280,6 @@ final class Mapbox extends AbstractHttpProvider implements Provider
 
         $results = [];
         foreach ($json['features'] as $result) {
-            if (!array_key_exists('context', $result)) {
-                break;
-            }
-
             $builder = new AddressBuilder($this->getName());
             $this->parseCoordinates($builder, $result);
 
@@ -298,8 +294,10 @@ final class Mapbox extends AbstractHttpProvider implements Provider
             }
 
             // update address components
-            foreach ($result['context'] as $component) {
-                $this->updateAddressComponent($builder, $component['id'], $component);
+            if (isset($result['context']) && is_array($result['context'])) {
+                foreach ($result['context'] as $component) {
+                    $this->updateAddressComponent($builder, $component['id'], $component);
+                }
             }
 
             /** @var MapboxAddress $address */


### PR DESCRIPTION
When searching for "New Zealand" or "Papua New Guinea" (there will definitely be others), Mapbox doesn't return a context key in the result. The package must handle this scenario without skipping the result.